### PR TITLE
Lagt til støtte for søk etter dokumenter basert på korrelasjonsid

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
     <fiks-maskinporten-client.version>1.0.15</fiks-maskinporten-client.version>
     <mockito-core.version>3.5.2</mockito-core.version>
     <commons-io.version>2.7</commons-io.version>
+    <jackson-datatype-jsr310.version>2.11.0</jackson-datatype-jsr310.version>
   </properties>
   <dependencies>
     <dependency>
@@ -79,6 +80,11 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>${commons-io.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>${jackson-datatype-jsr310.version}</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/no/ks/fiks/dokumentlager/klient/DokumentlagerApi.java
+++ b/src/main/java/no/ks/fiks/dokumentlager/klient/DokumentlagerApi.java
@@ -1,9 +1,6 @@
 package no.ks.fiks.dokumentlager.klient;
 
-import no.ks.fiks.dokumentlager.klient.model.DokumentMetadataDownloadResult;
-import no.ks.fiks.dokumentlager.klient.model.DokumentMetadataUpload;
-import no.ks.fiks.dokumentlager.klient.model.DokumentMetadataUploadResult;
-import no.ks.fiks.dokumentlager.klient.model.DokumentlagerResponse;
+import no.ks.fiks.dokumentlager.klient.model.*;
 
 import java.io.Closeable;
 import java.io.InputStream;
@@ -25,6 +22,12 @@ public interface DokumentlagerApi extends Closeable {
     DokumentlagerResponse<InputStream> downloadDokumentLazy(UUID dokumentId);
 
     DokumentlagerResponse<DokumentMetadataDownloadResult> downloadDokumentMetadata(UUID dokumentId);
+
+    DokumentlagerResponse<Sokeresultat> sokDokumenterMedKorrelasjonsid(UUID fiksOrganisasjonId,
+                                                UUID kontoId,
+                                                String korrelasjonsid,
+                                                Integer fra,
+                                                Integer til);
 
     DokumentlagerResponse<String> getPublicKey();
 }

--- a/src/main/java/no/ks/fiks/dokumentlager/klient/DokumentlagerApiImpl.java
+++ b/src/main/java/no/ks/fiks/dokumentlager/klient/DokumentlagerApiImpl.java
@@ -5,10 +5,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import net.minidev.json.JSONObject;
 import no.ks.fiks.dokumentlager.klient.authentication.AuthenticationStrategy;
 import no.ks.fiks.dokumentlager.klient.model.*;
 import no.ks.fiks.dokumentlager.klient.path.DefaultPathHandler;
 import no.ks.fiks.dokumentlager.klient.path.PathHandler;
+import org.apache.commons.io.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
@@ -25,6 +27,7 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.UUID;
@@ -201,10 +204,11 @@ public class DokumentlagerApiImpl implements DokumentlagerApi {
         log.debug("Search documents with correlationid {}", korrelasjonsid);
         try {
             ContentResponse response = newUploadRequest()
-                    .method(HttpMethod.GET)
-                    .path(pathHandler.getQueryDocumentPath(fiksOrganisasjonId, kontoId, korrelasjonsid))
+                    .method(HttpMethod.POST)
+                    .path(pathHandler.getQueryDocumentPath(fiksOrganisasjonId, kontoId))
                     .param("fra", String.valueOf(fra))
                     .param("til", String.valueOf(til))
+                    .content(new StringContentProvider("application/json","{\"korrelasjonsid\":\""+korrelasjonsid+"\"}", StandardCharsets.UTF_8))
                     .send();
 
             if (isError(response.getStatus())) {

--- a/src/main/java/no/ks/fiks/dokumentlager/klient/DokumentlagerKlient.java
+++ b/src/main/java/no/ks/fiks/dokumentlager/klient/DokumentlagerKlient.java
@@ -2,10 +2,7 @@ package no.ks.fiks.dokumentlager.klient;
 
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import no.ks.fiks.dokumentlager.klient.model.DokumentMetadataDownloadResult;
-import no.ks.fiks.dokumentlager.klient.model.DokumentMetadataUpload;
-import no.ks.fiks.dokumentlager.klient.model.DokumentMetadataUploadResult;
-import no.ks.fiks.dokumentlager.klient.model.DokumentlagerResponse;
+import no.ks.fiks.dokumentlager.klient.model.*;
 import no.ks.kryptering.CMSKrypteringImpl;
 import no.ks.kryptering.CMSStreamKryptering;
 import org.slf4j.MDC;
@@ -173,6 +170,14 @@ public class DokumentlagerKlient implements Closeable {
 
     public DokumentlagerResponse<DokumentMetadataDownloadResult> downloadMetadata(@NonNull UUID dokumentId) {
         return api.downloadDokumentMetadata(dokumentId);
+    }
+
+    public DokumentlagerResponse<Sokeresultat> sokDokumenterMedKorrelasjonsid(UUID fiksOrganisasjonId,
+                                                                              UUID kontoId,
+                                                                              String korrelasjonsid,
+                                                                              Integer fra,
+                                                                              Integer til){
+        return api.sokDokumenterMedKorrelasjonsid(fiksOrganisasjonId,kontoId,korrelasjonsid,fra,til);
     }
 
     @Override

--- a/src/main/java/no/ks/fiks/dokumentlager/klient/model/DokumentMetadataDownloadResult.java
+++ b/src/main/java/no/ks/fiks/dokumentlager/klient/model/DokumentMetadataDownloadResult.java
@@ -15,14 +15,16 @@ public class DokumentMetadataDownloadResult {
     private final String mimeType;
     private final Long kryptertStorrelse;
     private final Long ukryptertStorrelse;
+    private final String korrelasjonsid;
 
     @JsonCreator
-    public DokumentMetadataDownloadResult(@JsonProperty("id") @NonNull UUID id, @JsonProperty("dokumentnavn") @NonNull String dokumentnavn, @JsonProperty("mimeType") @NonNull String mimeType, @JsonProperty("kryptertStorrelse") @NonNull Long kryptertStorrelse, @JsonProperty("ukryptertStorrelse") @NonNull Long ukryptertStorrelse) {
+    public DokumentMetadataDownloadResult(@JsonProperty("id") @NonNull UUID id, @JsonProperty("dokumentnavn") @NonNull String dokumentnavn, @JsonProperty("mimeType") @NonNull String mimeType, @JsonProperty("kryptertStorrelse") @NonNull Long kryptertStorrelse, @JsonProperty("ukryptertStorrelse") @NonNull Long ukryptertStorrelse, @JsonProperty("korrelasjonsid") String korrelasjonsid) {
         this.id = id;
         this.dokumentnavn = dokumentnavn;
         this.mimeType = mimeType;
         this.kryptertStorrelse = kryptertStorrelse;
         this.ukryptertStorrelse = ukryptertStorrelse;
+        this.korrelasjonsid = korrelasjonsid;
     }
 
 }

--- a/src/main/java/no/ks/fiks/dokumentlager/klient/model/DokumentMetadataUpload.java
+++ b/src/main/java/no/ks/fiks/dokumentlager/klient/model/DokumentMetadataUpload.java
@@ -17,4 +17,5 @@ public class DokumentMetadataUpload {
     private Long ttl;
     private Set<EksponertFor> eksponertFor;
     private Integer sikkerhetsniva;
+    private String korrelasjonsid;
 }

--- a/src/main/java/no/ks/fiks/dokumentlager/klient/model/DokumentMetadataUpload.java
+++ b/src/main/java/no/ks/fiks/dokumentlager/klient/model/DokumentMetadataUpload.java
@@ -2,6 +2,7 @@ package no.ks.fiks.dokumentlager.klient.model;
 
 import lombok.Builder;
 import lombok.Data;
+import lombok.ToString;
 import lombok.Value;
 import no.ks.fiks.dokumentlager.klient.model.eksponertfor.EksponertFor;
 
@@ -12,6 +13,7 @@ import java.util.Set;
 @Data
 @Builder
 public class DokumentMetadataUpload {
+    @ToString.Exclude
     private String dokumentnavn;
     private String mimetype;
     private Long ttl;

--- a/src/main/java/no/ks/fiks/dokumentlager/klient/model/Sokeresultat.java
+++ b/src/main/java/no/ks/fiks/dokumentlager/klient/model/Sokeresultat.java
@@ -1,0 +1,22 @@
+package no.ks.fiks.dokumentlager.klient.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.NonNull;
+import lombok.Value;
+
+import java.util.List;
+
+@Value
+public class Sokeresultat {
+
+    private final Integer totaltAntallTreff;
+    private final List<Soketreff> dokumenter;
+
+    @JsonCreator
+    public Sokeresultat(@JsonProperty("totaltAntallTreff") @NonNull Integer totaltAntallTreff, @JsonProperty("dokumenter") @NonNull List<Soketreff> dokumenter) {
+        this.totaltAntallTreff = totaltAntallTreff;
+        this.dokumenter = dokumenter;
+    }
+
+}

--- a/src/main/java/no/ks/fiks/dokumentlager/klient/model/Soketreff.java
+++ b/src/main/java/no/ks/fiks/dokumentlager/klient/model/Soketreff.java
@@ -1,0 +1,45 @@
+package no.ks.fiks.dokumentlager.klient.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.NonNull;
+import lombok.Value;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Value
+public class Soketreff {
+
+    private final UUID id;
+    private final String dokumentnavn;
+    private final Long kryptertStorrelse;
+    private final Long ukryptertStorrelse;
+    private final Boolean lest;
+    private final OffsetDateTime opprettet;
+    private final String mimetype;
+    private final Boolean slettet;
+    private final String korrelasjonsid;
+
+    @JsonCreator
+    public Soketreff(
+            @JsonProperty("id") @NonNull UUID id,
+            @JsonProperty("dokumentnavn") @NonNull String dokumentnavn,
+            @JsonProperty("kryptertStorrelse") @NonNull Long kryptertStorrelse,
+            @JsonProperty("ukryptertStorrelse") @NonNull Long ukryptertStorrelse,
+            @JsonProperty("lest") @NonNull Boolean lest,
+            @JsonProperty("opprettet") @NonNull OffsetDateTime opprettet,
+            @JsonProperty("mimetype") @NonNull String mimetype,
+            @JsonProperty("slettet") @NonNull Boolean slettet,
+            @JsonProperty("korrelasjonsid") @NonNull String korrelasjonsid) {
+        this.id = id;
+        this.dokumentnavn = dokumentnavn;
+        this.kryptertStorrelse = kryptertStorrelse;
+        this.ukryptertStorrelse = ukryptertStorrelse;
+        this.lest = lest;
+        this.opprettet = opprettet;
+        this.mimetype = mimetype;
+        this.slettet = slettet;
+        this.korrelasjonsid = korrelasjonsid;
+    }
+}

--- a/src/main/java/no/ks/fiks/dokumentlager/klient/path/DefaultPathHandler.java
+++ b/src/main/java/no/ks/fiks/dokumentlager/klient/path/DefaultPathHandler.java
@@ -31,4 +31,9 @@ public class DefaultPathHandler implements PathHandler {
         return String.format("/dokumentlager/nedlasting/%s/metadata", dokumentId);
     }
 
+    @Override
+    public String getQueryDocumentPath(UUID fiksOrganisasjonId, UUID kontoId, String korrelasjonsid) {
+        return String.format("%s/%s/kontoer/%s/dokumenter/sok/%s", UPLOAD_BASE_PATH, fiksOrganisasjonId, kontoId, korrelasjonsid);
+    }
+
 }

--- a/src/main/java/no/ks/fiks/dokumentlager/klient/path/DefaultPathHandler.java
+++ b/src/main/java/no/ks/fiks/dokumentlager/klient/path/DefaultPathHandler.java
@@ -32,8 +32,8 @@ public class DefaultPathHandler implements PathHandler {
     }
 
     @Override
-    public String getQueryDocumentPath(UUID fiksOrganisasjonId, UUID kontoId, String korrelasjonsid) {
-        return String.format("%s/%s/kontoer/%s/dokumenter/sok/%s", UPLOAD_BASE_PATH, fiksOrganisasjonId, kontoId, korrelasjonsid);
+    public String getQueryDocumentPath(UUID fiksOrganisasjonId, UUID kontoId) {
+        return String.format("%s/%s/kontoer/%s/dokumenter/sok", UPLOAD_BASE_PATH, fiksOrganisasjonId, kontoId);
     }
 
 }

--- a/src/main/java/no/ks/fiks/dokumentlager/klient/path/PathHandler.java
+++ b/src/main/java/no/ks/fiks/dokumentlager/klient/path/PathHandler.java
@@ -4,8 +4,14 @@ import java.util.UUID;
 
 public interface PathHandler {
     String getUploadPath(UUID fiksOrganisasjonId, UUID kontoId);
+
     String getDeletePath(UUID fiksOrganisasjonId, UUID kontoId, UUID dokumentId);
+
     String getPublicKeyPath();
+
     String getDownloadPath(UUID dokumentId);
+
     String getDownloadMetadataPath(UUID dokumentId);
+
+    String getQueryDocumentPath(UUID fiksOrganisasjonId, UUID kontoId, String korrelasjonsid);
 }

--- a/src/main/java/no/ks/fiks/dokumentlager/klient/path/PathHandler.java
+++ b/src/main/java/no/ks/fiks/dokumentlager/klient/path/PathHandler.java
@@ -13,5 +13,5 @@ public interface PathHandler {
 
     String getDownloadMetadataPath(UUID dokumentId);
 
-    String getQueryDocumentPath(UUID fiksOrganisasjonId, UUID kontoId, String korrelasjonsid);
+    String getQueryDocumentPath(UUID fiksOrganisasjonId, UUID kontoId);
 }


### PR DESCRIPTION
Utvidet api til å støtte søk etter dokumenter med korrelasjonsid

Har samtidig tatt bort dokumentnavn fra toString i DokumentMetadataUpload, slik at det ikke skal komme ut i loggene